### PR TITLE
Custom config reader for reading data sources

### DIFF
--- a/thirdeye-frontend/config/environment.js
+++ b/thirdeye-frontend/config/environment.js
@@ -25,7 +25,8 @@ module.exports = function(environment) {
 
     https_only: false,
 
-    timeZone: "America/Los_Angeles",
+    // timeZone: "America/Los_Angeles",
+    timeZone: "Asia/Calcutta",
 
     moment: {
       includeTimezone: 'all'
@@ -47,7 +48,7 @@ module.exports = function(environment) {
       cubeWiki: "/link/to/cubeAlgorithm/wiki"
     },
 
-    // used to split username if needed.  
+    // used to split username if needed.
     userNameSplitToken: ' ',
 
     EmberENV: {

--- a/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/cube/additive/AdditiveDBClient.java
+++ b/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/cube/additive/AdditiveDBClient.java
@@ -57,6 +57,10 @@ public class AdditiveDBClient extends BaseCubePinotClient<AdditiveRow> {
     this.metric = Preconditions.checkNotNull(metric);
   }
 
+  public String getMetric() {
+    return metric;
+  }
+
   @Override
   protected List<CubeSpec> getCubeSpecs() {
     List<CubeSpec> cubeSpecs = new ArrayList<>();

--- a/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/cube/data/cube/Cube.java
+++ b/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/cube/data/cube/Cube.java
@@ -22,6 +22,7 @@ package org.apache.pinot.thirdeye.cube.data.cube;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Multimap;
 import org.apache.pinot.thirdeye.anomaly.utils.ThirdeyeMetricsUtil;
+import org.apache.pinot.thirdeye.cube.additive.AdditiveDBClient;
 import org.apache.pinot.thirdeye.cube.data.dbrow.Dimensions;
 import org.apache.pinot.thirdeye.cube.cost.CostFunction;
 import java.io.File;
@@ -228,6 +229,11 @@ public class Cube { // the cube (Ca|Cb)
   private void initializeBasicInfo(CubeClient olapClient, Multimap<String, String> filterSets)
       throws Exception {
 
+    String metric = null;
+    if (olapClient instanceof AdditiveDBClient) {
+      metric = ((AdditiveDBClient)olapClient).getMetric();
+      filterSets.put("metric", metric);
+    }
     Row topAggValues = olapClient.getTopAggregatedValues(filterSets);
     CubeNode node = topAggValues.toNode();
 

--- a/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/util/DaoProviderUtil.java
+++ b/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datalayer/util/DaoProviderUtil.java
@@ -33,6 +33,7 @@ import org.apache.pinot.thirdeye.datalayer.ThirdEyePersistenceModule;
 import org.apache.pinot.thirdeye.datalayer.bao.jdbc.AbstractManagerImpl;
 import org.apache.pinot.thirdeye.datalayer.dto.AbstractDTO;
 import org.apache.pinot.thirdeye.datalayer.util.PersistenceConfig.DatabaseConfiguration;
+import org.apache.pinot.thirdeye.util.CustomConfigReader;
 import org.apache.tomcat.jdbc.pool.DataSource;
 import org.h2.store.fs.FileUtils;
 import org.slf4j.Logger;
@@ -81,12 +82,13 @@ public abstract class DaoProviderUtil {
 
   private static DataSource createDataSource(final PersistenceConfig configuration) {
     final DataSource dataSource = new DataSource();
+    CustomConfigReader ccr = new CustomConfigReader();
     dataSource.setInitialSize(10);
     dataSource.setDefaultAutoCommit(false);
     dataSource.setMaxActive(100);
-    dataSource.setUsername(configuration.getDatabaseConfiguration().getUser());
-    dataSource.setPassword(configuration.getDatabaseConfiguration().getPassword());
-    dataSource.setUrl(configuration.getDatabaseConfiguration().getUrl());
+    dataSource.setUsername(ccr.readEnv(configuration.getDatabaseConfiguration().getUser()));
+    dataSource.setPassword(ccr.readEnv(configuration.getDatabaseConfiguration().getPassword()));
+    dataSource.setUrl(ccr.readEnv(configuration.getDatabaseConfiguration().getUrl()));
     dataSource.setDriverClassName(configuration.getDatabaseConfiguration().getDriver());
 
     dataSource.setValidationQuery("select 1");

--- a/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotThirdEyeDataSourceConfig.java
+++ b/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/datasource/pinot/PinotThirdEyeDataSourceConfig.java
@@ -27,6 +27,7 @@ import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.thirdeye.auto.onboard.AutoOnboardPinotMetadataSource;
 import org.apache.pinot.thirdeye.datasource.MetadataSourceConfig;
+import org.apache.pinot.thirdeye.util.CustomConfigReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -212,13 +213,15 @@ public class PinotThirdEyeDataSourceConfig {
           "{} accepts only 'http' or 'https' connection schemes", className);
 
       PinotThirdEyeDataSourceConfig config = new PinotThirdEyeDataSourceConfig();
-      config.setControllerHost(controllerHost);
+      // Read from the custom config reader for reading from environment variables
+      CustomConfigReader ccr = new CustomConfigReader();
+      config.setControllerHost(ccr.readEnv(controllerHost));
       config.setControllerPort(controllerPort);
-      config.setZookeeperUrl(zookeeperUrl);
-      config.setClusterName(clusterName);
-      config.setBrokerUrl(brokerUrl);
-      config.setTag(tag);
-      config.setControllerConnectionScheme(controllerConnectionScheme);
+      config.setZookeeperUrl(ccr.readEnv(zookeeperUrl));
+      config.setClusterName(ccr.readEnv(clusterName));
+      config.setBrokerUrl(ccr.readEnv(brokerUrl));
+      config.setTag(ccr.readEnv(tag));
+      config.setControllerConnectionScheme(ccr.readEnv(controllerConnectionScheme));
       config.setName(name);
       return config;
     }

--- a/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/util/CustomConfigReader.java
+++ b/thirdeye-pinot/src/main/java/org/apache/pinot/thirdeye/util/CustomConfigReader.java
@@ -1,0 +1,26 @@
+package org.apache.pinot.thirdeye.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CustomConfigReader {
+	public String readEnv(String inputStr) {
+		final String regex = "\\?\\$[A-Z0-9_]*";
+		final Pattern pattern = Pattern.compile(regex);
+		final Matcher matcher = pattern.matcher(inputStr);
+
+		while (matcher.find()) {
+			String matchStr = matcher.group(0);
+			String env = matchStr.substring(2);
+			String value = System.getenv(env);
+			if (value != null) {
+				// replace original string with configured env variables
+				inputStr = inputStr.replace(matchStr, value);
+			} else {
+				System.out.format("%s is" + " not assigned.%n", env);
+			}
+		}
+
+		return inputStr;
+	}
+}


### PR DESCRIPTION
## Description
This PR adds a custom config reader to read configurations from environment variables.
### Why is this needed
Specifically in container environments like docker and kubernetes, we might have multiple environments and also possibly want to control secrets and configurations using kubernetes secrets / configmaps. In addition, we do not want to commit these credentials into code as well. So, in essence, instead of directly file mounting the `data-sources-config.yml` as a secret, we can selectively define some of the configs like hostname, port, username, password etc as kubernetes or docker secrets. 
E.g.: Our default `data-sources-config.yml` might look like this:
```
...
properties:
      MySQL:
        - db:
            mysql: jdbc:mysql://?somemysqlhost:3306/?thirdeye
          user: thirdeye_user
          password: thirdeye_password
...
 ```
With this PR, we can do the following:
```
- className: org.apache.pinot.thirdeye.datasource.sql.SqlThirdEyeDataSource
    properties:
      MySQL:
        - db:
            mysql: jdbc:mysql://?$MYSQL_HOSTNAME:?$MYSQL_PORT/?$THIRDEYE_DATABASE?allowPublicKeyRetrieval=true&
          user: ?$MYSQL_USERNAME
          password: ?$MYSQL_PASSWORD
```
And then the kubernetes deployment will look like the following:
```
...
- name: MYSQL_USERNAME
   valueFrom:
      secretKeyRef:
        key: MYSQL_USERNAME
        name: thirdeye
- name: MYSQL_PASSWORD
   valueFrom:
      secretKeyRef:
        key: MYSQL_PASSWORD
        name: thirdeye
 ....
```
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New Config Options : As mentioned earlier, the new data store configs are provided above 
- TODO: Update the thirdeye documentation to provide examples for the same
* [X] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
- This Section needs a bit of update based on updates to the documentation. 

## Documentation
TODO
