### PR TITLE
Add Package Manager Guard (PMG) to CI workflows

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,6 +28,9 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -37,6 +40,18 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    # Package Manager Guard. Runs after setup-java so the JDK download is not
+    # routed through the proxy. The thirdeye-frontend module shells out to yarn
+    # via frontend-maven-plugin, so the Maven build below is what gets guarded.
+    - name: Set up Package Manager Guard
+      uses: safedep/pmg@v1
+      with:
+        server-mode: true
+        api-key: ${{ secrets.SAFEDEP_API_KEY }}
+        tenant-id: ${{ secrets.SAFEDEP_TENANT_ID }}
     - name: Build with Maven
       run: |
         mvn -T 1C clean compile package
+    - name: Enforce PMG policy
+      if: always()
+      run: pmg proxy stop --fail-on-violation

--- a/.github/workflows/thirdeye_tests.yml
+++ b/.github/workflows/thirdeye_tests.yml
@@ -26,6 +26,9 @@ on:
       - "docs/**"
       - "**.md"
 
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     runs-on: ubuntu-latest
@@ -35,8 +38,22 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      # Package Manager Guard. Runs after setup-java so the JDK download is not
+      # routed through the proxy. `mvn test` drives yarn install / yarn run test
+      # in the thirdeye-frontend module, which is what gets guarded here.
+      - name: Set up Package Manager Guard
+        uses: safedep/pmg@v1
+        with:
+          server-mode: true
+          api-key: ${{ secrets.SAFEDEP_API_KEY }}
+          tenant-id: ${{ secrets.SAFEDEP_TENANT_ID }}
       - name: Unit Test
         run: .github/workflows/scripts/.thirdeye_test.sh
       - name: Upload coverage to Codecov
         run: |
           bash <(curl -s https://codecov.io/bash) -cF unittests
+      # Must stay the last step: stopping the proxy leaves HTTP_PROXY set in the
+      # job env, so any network step placed after this would point at a dead proxy.
+      - name: Enforce PMG policy
+        if: always()
+        run: pmg proxy stop --fail-on-violation


### PR DESCRIPTION
## What

Adds [SafeDep PMG](https://docs.safedep.io/package-security/pmg/github-actions) install-time malware blocking to the two CI workflows that install packages.

| Workflow | Change |
|---|---|
| `maven.yml` | PMG added |
| `thirdeye_tests.yml` | PMG added |
| `thirdeye_tests-workflow-run.yml` | **Not changed** — only runs `cancel-workflow-runs`, installs nothing |

Each modified workflow gets:
- `permissions: contents: read`
- `safedep/pmg@v1` with `server-mode: true`, placed **after** `setup-java` so the JDK download isn't routed through the proxy
- a final `pmg proxy stop --fail-on-violation` step with `if: always()`

## Why this repo is in scope

It looks like a pure Java/Maven repo, and PMG does **not** support Maven — so the initial read was "out of scope."

It isn't. `thirdeye-frontend` is a module in the root reactor, and `thirdeye-frontend/pom.xml` uses `frontend-maven-plugin` to shell out to `yarn install`, `yarn run build`, and `yarn run test`. So both workflows install npm packages during the Maven build — just indirectly. PMG's server mode catches this because it exports `HTTP_PROXY` and those env vars propagate to the child yarn process.

## Coverage limits — please read

**This guards the npm/yarn side only.** Maven's own jar resolution from Central is *not* covered: PMG works via `HTTP_PROXY`, and the JVM ignores that env var by default. Five of six modules and the entire Java dependency graph are untouched by this change. Covering those needs a manifest scanner (SafeDep `vet` supports Maven) — out of scope here.

## Risks

1. **PMG may block a package and fail the build.** `thirdeye-frontend/yarn.lock` is a 2021-era tree with 2098 entries. Spot-checked `rc` (pinned 1.2.8) and `faker` (pinned 3.1.0) — both clean, predating their respective incidents. That's 2 of 2098, so if anything else is flagged in SafeDep's threat intel the job fails. That's PMG working as intended, but expect it.

2. **Codecov step.** `bash <(curl -s https://codecov.io/bash)` now routes through the PMG proxy, since curl honors `HTTP_PROXY`. Expected to pass through fine, but it's the one behavior not confirmed from the docs.

⚠️ **The enforce step must stay last in `thirdeye_tests.yml`.** Stopping the proxy leaves `HTTP_PROXY` set in the job env, so any network step ordered after it would point at a dead proxy. There's an inline comment saying so.

## Notes

- SafeDep secrets are optional — if `SAFEDEP_API_KEY` / `SAFEDEP_TENANT_ID` aren't configured they resolve to empty strings (the action's default) and PMG runs local-only. `maven.yml` triggers on `pull_request`, and fork PRs never receive secrets, so those runs are always local-only regardless.
- PMG's dependency cooldown defaults to on (5 days). The lockfile is committed and pinned, so this shouldn't fire.
- `safedep/pmg@v1` is a moving tag. This repo pins `potiuk/cancel-workflow-runs` to a full SHA — worth pinning PMG the same way if that's a deliberate convention.

## Pre-existing issue, not introduced here

Both workflows use `actions/checkout@v2` and `actions/setup-java@v1`, which are effectively EOL. **CI may already be failing for this reason** — worth confirming the baseline before attributing any red run to PMG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
